### PR TITLE
[Editorial] expose -> exposé

### DIFF
--- a/src/epub/text/chapter-18.xhtml
+++ b/src/epub/text/chapter-18.xhtml
@@ -55,7 +55,7 @@
 			<p>“You don’t mind my staying?” inquired John Quincy.</p>
 			<p>“Not in the least, my boy. Our business here will take but a moment.” He turned to Greene. “Just as a preliminary,” he continued, “I am Captain Arthur Temple Cope of the British Admiralty, and this gentleman”⁠—he nodded toward the proprietor of the Reef and Palm⁠—“is my brother.”</p>
 			<p>“Really?” said Greene. “His name is Egan, as I understand it.”</p>
-			<p>“His name is James Egan Cope,” the captain replied. “He dropped the Cope many years ago for reasons that do not concern us now. I am here simply to say, sir, that you are holding my brother on the flimsiest pretext I have ever encountered in the course of my rather extensive travels. If necessary, I propose to engage the best lawyer in Honolulu and have him free by night. But I’m giving you this last chance to release him and avoid a somewhat painful expose of the sort of nonsense you go in for.”</p>
+			<p>“His name is James Egan Cope,” the captain replied. “He dropped the Cope many years ago for reasons that do not concern us now. I am here simply to say, sir, that you are holding my brother on the flimsiest pretext I have ever encountered in the course of my rather extensive travels. If necessary, I propose to engage the best lawyer in Honolulu and have him free by night. But I’m giving you this last chance to release him and avoid a somewhat painful exposé of the sort of nonsense you go in for.”</p>
 			<p>John Quincy glanced at Carlota Egan. Her eyes were shining but not on him. They were on her uncle.</p>
 			<p>Greene flushed slightly. “A good bluff, Captain, is always worth trying,” he said.</p>
 			<p>“Oh, then you admit you’ve been bluffing,” said Cope quickly.</p>


### PR DESCRIPTION
The page scans use "expose", and m-w lists this as an uncommon variant for "exposé", but for clarity I'm proposing to use the accented spelling.